### PR TITLE
Don't use hardcoded sodium.h location

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module Sodium [system] {
-  header "/usr/local/include/sodium.h"
+  header "shim.h"
   link "sodium"
   export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,1 @@
+#include <sodium.h>


### PR DESCRIPTION
Hopefully this will allow you to use a single version of Sodium for both macOS and Linux